### PR TITLE
fix(VtkThreeView): alpha range fixed to data range

### DIFF
--- a/src/components/VtkThreeView.vue
+++ b/src/components/VtkThreeView.vue
@@ -224,7 +224,6 @@ export default defineComponent({
       const pwf = proxyManager.getPiecewiseFunction(arrayName);
       const opFunc = opacityFunction.value;
       pwf.setMode(opFunc.mode);
-      pwf.setDataRange(...mappingRange);
 
       switch (opFunc.mode) {
         case vtkPiecewiseFunctionProxy.Mode.Gaussians:


### PR DESCRIPTION
The opacity mapping range was being set alongside the colormap mapping range. We only want the colormap mapping range to be updated.