### PR TITLE
feat(ToolStrip): Add buttons for PanTool and ZoomTool

### DIFF
--- a/src/components/ToolStrip.vue
+++ b/src/components/ToolStrip.vue
@@ -13,6 +13,26 @@
         @click="toggle"
       />
     </groupable-item>
+    <groupable-item v-slot:default="{ active, toggle }" :value="Tools.Pan">
+      <tool-button
+        size="40"
+        icon="mdi-cursor-move"
+        name="Pan"
+        :buttonClass="['tool-btn', active ? 'tool-btn-selected' : '']"
+        :disabled="noCurrentImage"
+        @click="toggle"
+      />
+    </groupable-item>
+    <groupable-item v-slot:default="{ active, toggle }" :value="Tools.Zoom">
+      <tool-button
+        size="40"
+        icon="mdi-magnify-plus-outline"
+        name="Zoom"
+        :buttonClass="['tool-btn', active ? 'tool-btn-selected' : '']"
+        :disabled="noCurrentImage"
+        @click="toggle"
+      />
+    </groupable-item>
     <groupable-item v-slot:default="{ active, toggle }" :value="Tools.Paint">
       <v-menu
         v-model="paintMenu"

--- a/src/components/tools/ManipulatorTool.vue
+++ b/src/components/tools/ManipulatorTool.vue
@@ -4,6 +4,7 @@ import {
   onBeforeUnmount,
   onMounted,
   toRefs,
+  watch,
 } from '@vue/composition-api';
 import vtkViewProxy from '@kitware/vtk.js/Proxy/Core/ViewProxy';
 import { useViewStore } from '@/src/store/views';
@@ -40,6 +41,14 @@ export default defineComponent({
       ? viewProxy.getInteractorStyle2D()
       : viewProxy.getInteractorStyle3D();
     const manipulator = manipulatorClass.value.newInstance(options.value);
+
+    watch(options, (newOptions) => {
+      if (props.name === 'PanTool') {
+        manipulator.setShift(!newOptions.shift.value);
+      } else if (props.name === 'ZoomTool') {
+        manipulator.setControl(!newOptions.control.value);
+      }
+    });
 
     onMounted(() => {
       if (manipulator.isA('vtkCompositeMouseManipulator')) {

--- a/src/components/tools/ManipulatorTool.vue
+++ b/src/components/tools/ManipulatorTool.vue
@@ -43,10 +43,14 @@ export default defineComponent({
     const manipulator = manipulatorClass.value.newInstance(options.value);
 
     watch(options, (newOptions) => {
-      if (props.name === 'PanTool') {
-        manipulator.setShift(!newOptions.shift.value);
-      } else if (props.name === 'ZoomTool') {
-        manipulator.setControl(!newOptions.control.value);
+      if ('button' in newOptions) {
+        manipulator.setButton(newOptions.button);
+      }
+      if ('shift' in newOptions) {
+        manipulator.setShift(newOptions.shift);
+      }
+      if ('control' in newOptions) {
+        manipulator.setControl(newOptions.control);
       }
     });
 

--- a/src/components/tools/PanTool.vue
+++ b/src/components/tools/PanTool.vue
@@ -1,7 +1,9 @@
 <script lang="ts">
+import { computed } from '@vue/composition-api';
 import { CreateElement, RenderContext } from 'vue';
 import vtkViewProxy from '@kitware/vtk.js/Proxy/Core/ViewProxy';
 import vtkMouseCameraTrackballPanManipulator from '@kitware/vtk.js/Interaction/Manipulators/MouseCameraTrackballPanManipulator';
+import { Tools, useToolStore } from '@/src/store/tools';
 import ManipulatorTool from './ManipulatorTool.vue';
 
 interface Props {
@@ -11,6 +13,9 @@ interface Props {
 export default {
   functional: true,
   render(h: CreateElement, ctx: RenderContext<Props>) {
+    const toolStore = useToolStore();
+    const active = computed(() => toolStore.currentTool === Tools.Pan);
+
     return h(ManipulatorTool, {
       props: {
         ...ctx.props,
@@ -18,7 +23,7 @@ export default {
         manipulatorClass: vtkMouseCameraTrackballPanManipulator,
         options: {
           button: 1,
-          shift: true,
+          shift: active,
         },
       },
     });

--- a/src/components/tools/PanTool.vue
+++ b/src/components/tools/PanTool.vue
@@ -1,5 +1,4 @@
 <script lang="ts">
-import { computed } from '@vue/composition-api';
 import { CreateElement, RenderContext } from 'vue';
 import vtkViewProxy from '@kitware/vtk.js/Proxy/Core/ViewProxy';
 import vtkMouseCameraTrackballPanManipulator from '@kitware/vtk.js/Interaction/Manipulators/MouseCameraTrackballPanManipulator';
@@ -14,7 +13,8 @@ export default {
   functional: true,
   render(h: CreateElement, ctx: RenderContext<Props>) {
     const toolStore = useToolStore();
-    const active = computed(() => toolStore.currentTool === Tools.Pan);
+    // only enable shift if Pan tool is not active
+    const shift = toolStore.currentTool !== Tools.Pan;
 
     return h(ManipulatorTool, {
       props: {
@@ -23,7 +23,7 @@ export default {
         manipulatorClass: vtkMouseCameraTrackballPanManipulator,
         options: {
           button: 1,
-          shift: active,
+          shift,
         },
       },
     });

--- a/src/components/tools/ZoomTool.vue
+++ b/src/components/tools/ZoomTool.vue
@@ -1,7 +1,9 @@
 <script lang="ts">
+import { computed } from '@vue/composition-api';
 import { CreateElement, RenderContext } from 'vue';
 import vtkViewProxy from '@kitware/vtk.js/Proxy/Core/ViewProxy';
 import vtkMouseCameraTrackballZoomManipulator from '@kitware/vtk.js/Interaction/Manipulators/MouseCameraTrackballZoomManipulator';
+import { Tools, useToolStore } from '@/src/store/tools';
 import ManipulatorTool from './ManipulatorTool.vue';
 
 interface Props {
@@ -11,6 +13,9 @@ interface Props {
 export default {
   functional: true,
   render(h: CreateElement, ctx: RenderContext<Props>) {
+    const toolStore = useToolStore();
+    const active = computed(() => toolStore.currentTool === Tools.Zoom);
+
     return h(ManipulatorTool, {
       props: {
         ...ctx.props,
@@ -18,7 +23,7 @@ export default {
         manipulatorClass: vtkMouseCameraTrackballZoomManipulator,
         options: {
           button: 1,
-          control: true,
+          control: active,
         },
       },
     });

--- a/src/components/tools/ZoomTool.vue
+++ b/src/components/tools/ZoomTool.vue
@@ -1,8 +1,7 @@
 <script lang="ts">
-import { computed } from '@vue/composition-api';
 import { CreateElement, RenderContext } from 'vue';
 import vtkViewProxy from '@kitware/vtk.js/Proxy/Core/ViewProxy';
-import vtkMouseCameraTrackballZoomManipulator from '@kitware/vtk.js/Interaction/Manipulators/MouseCameraTrackballZoomManipulator';
+import vtkMouseCameraTrackballZoomToMouseManipulator from '@kitware/vtk.js/Interaction/Manipulators/MouseCameraTrackballZoomToMouseManipulator';
 import { Tools, useToolStore } from '@/src/store/tools';
 import ManipulatorTool from './ManipulatorTool.vue';
 
@@ -14,16 +13,17 @@ export default {
   functional: true,
   render(h: CreateElement, ctx: RenderContext<Props>) {
     const toolStore = useToolStore();
-    const active = computed(() => toolStore.currentTool === Tools.Zoom);
+    // only enable control button if Zoom tool is not active
+    const control = toolStore.currentTool !== Tools.Zoom;
 
     return h(ManipulatorTool, {
       props: {
         ...ctx.props,
         name: 'ZoomTool',
-        manipulatorClass: vtkMouseCameraTrackballZoomManipulator,
+        manipulatorClass: vtkMouseCameraTrackballZoomToMouseManipulator,
         options: {
           button: 1,
-          control: active,
+          control,
         },
       },
     });

--- a/src/shims-vtk.d.ts
+++ b/src/shims-vtk.d.ts
@@ -626,6 +626,33 @@ declare module '@kitware/vtk.js/Interaction/Manipulators/MouseCameraTrackballZoo
   export default vtkMouseCameraTrackballZoomManipulator;
 }
 
+declare module '@kitware/vtk.js/Interaction/Manipulators/MouseCameraTrackballZoomToMouseManipulator' {
+  import vtkMouseCameraTrackballZoomManipulator, {
+    IMouseCameraTrackballZoomManipulatorInitialValues,
+  } from '@kitware/vtk.js/Interaction/Manipulators/MouseCameraTrackballZoomManipulator';
+  export interface IMouseCameraTrackballZoomToMouseManipulator
+    extends IMouseCameraTrackballZoomManipulatorInitialValues {}
+
+  export interface vtkMouseCameraTrackballZoomToMouseManipulator
+    extends vtkMouseCameraTrackballZoomManipulator {}
+
+  export function extend(
+    publicAPI: object,
+    model: object,
+    initialValues?: IMouseCameraTrackballZoomToMouseManipulatorInitialValues
+  ): void;
+  export function newInstance(
+    initialValues?: IMouseCameraTrackballZoomToMouseManipulatorInitialValues
+  ): vtkMouseCameraTrackballZoomToMouseManipulator;
+
+  export declare const vtkMouseCameraTrackballZoomToMouseManipulator: {
+    newInstance: typeof newInstance;
+    extend: typeof extend;
+  };
+
+  export default vtkMouseCameraTrackballZoomToMouseManipulator;
+}
+
 declare module '@kitware/vtk.js/Interaction/Style/InteractorStyleManipulator/Presets' {
   export default any;
 }

--- a/src/store/tools/index.ts
+++ b/src/store/tools/index.ts
@@ -5,6 +5,8 @@ import { useRulerToolStore } from './rulers';
 
 export enum Tools {
   WindowLevel = 'WindowLevel',
+  Pan = 'Pan',
+  Zoom = 'Zoom',
   Ruler = 'Ruler',
   Paint = 'Paint',
   Crosshairs = 'Crosshairs',


### PR DESCRIPTION
Add buttons for the PanTool and the ZoomTool in the ToolStrip.
When clicked, these tools replace de default interaction (window&level) and
can be used with left click + drag.