### PR TITLE
fix: update SVG points on container resize

### DIFF
--- a/src/components/tools/crosshairs/CrosshairSVG2D.vue
+++ b/src/components/tools/crosshairs/CrosshairSVG2D.vue
@@ -1,5 +1,5 @@
 <template>
-  <g>
+  <g ref="containerEl">
     <line
       v-if="x != null && y != null"
       :x1="x"
@@ -41,6 +41,7 @@
 
 <script lang="ts">
 import { manageVTKSubscription } from '@/src/composables/manageVTKSubscription';
+import { useResizeObserver } from '@/src/composables/useResizeObserver';
 import { useViewStore } from '@/src/store/views';
 import { worldToSVG } from '@/src/utils/vtk-helpers';
 import vtkLPSView2DProxy from '@/src/vtk/LPSView2DProxy';
@@ -97,10 +98,19 @@ export default defineComponent({
 
     watchEffect(updatePoints);
 
+    // --- resize --- //
+
+    const containerEl = ref<Element | null>(null);
+
+    useResizeObserver(containerEl, () => {
+      updatePoints();
+    });
+
     return {
       devicePixelRatio,
       x: computed(() => position2D.value?.x),
       y: computed(() => position2D.value?.y),
+      containerEl,
     };
   },
 });

--- a/src/components/tools/ruler/RulerSVG2D.vue
+++ b/src/components/tools/ruler/RulerSVG2D.vue
@@ -1,5 +1,5 @@
 <template>
-  <g>
+  <g ref="containerEl">
     <line
       v-if="first && second"
       :x1="first.x"
@@ -47,6 +47,7 @@
 
 <script lang="ts">
 import { manageVTKSubscription } from '@/src/composables/manageVTKSubscription';
+import { useResizeObserver } from '@/src/composables/useResizeObserver';
 import { useViewStore } from '@/src/store/views';
 import { worldToSVG } from '@/src/utils/vtk-helpers';
 import vtkLPSView2DProxy from '@/src/vtk/LPSView2DProxy';
@@ -145,6 +146,14 @@ export default defineComponent({
       return { dx: -offset, dy: -offset, anchor: 'end' };
     });
 
+    // --- resize --- //
+
+    const containerEl = ref<Element | null>(null);
+
+    useResizeObserver(containerEl, () => {
+      updatePoints();
+    });
+
     return {
       devicePixelRatio,
       textdx: computed(() => textProperties.value?.dx ?? 0),
@@ -153,6 +162,7 @@ export default defineComponent({
       first: firstPoint,
       second: secondPoint,
       rulerLength: computed(() => length?.value?.toFixed(2) ?? ''),
+      containerEl,
     };
   },
 });

--- a/src/core/tools/paint/index.ts
+++ b/src/core/tools/paint/index.ts
@@ -1,3 +1,4 @@
+import { clampValue } from '@/src/utils';
 import vtkLabelMap from '@/src/vtk/LabelMap';
 import vtkPaintWidget from '@/src/vtk/PaintWidget';
 import { vec3 } from 'gl-matrix';
@@ -95,7 +96,11 @@ export default class PaintTool {
     scale.splice(sliceAxis, 1);
     const stamp = rescaleStamp(this.brush.getStamp(), scale, true);
 
-    const start = [...startPoint.map((val) => Math.floor(val))];
+    const start = [
+      // transforms + floating point errors can make zero values occasionally
+      // turn into really tiny negative values
+      ...startPoint.map((val) => Math.floor(clampValue(val, 0, Infinity))),
+    ];
     // Assumption: startPoint and endPoint are on the same slice axis.
     const ijkSlice = start[sliceAxis];
     start.splice(sliceAxis, 1);

--- a/src/store/tools/rulers.ts
+++ b/src/store/tools/rulers.ts
@@ -256,12 +256,16 @@ export const useRulerStore = defineStore('ruler', () => {
     updateRulerInternal.call(this, id, patch);
   }
 
+  let cleanup: Function;
+
   function initialize(this: _This) {
-    this.$rulers.events.on('widgetUpdate', updateFromWidgetState.bind(this));
+    const update = updateFromWidgetState.bind(this);
+    this.$rulers.events.on('widgetUpdate', update);
+    cleanup = () => this.$rulers.events.off('widgetUpdate', update);
   }
 
   function uninitialize(this: _This) {
-    this.$rulers.events.off('widgetUpdate', updateFromWidgetState.bind(this));
+    cleanup();
   }
 
   // --- tool activation --- //


### PR DESCRIPTION
- Ruler and crosshairs were not updating when the window gets resized.
- paint wasn't drawing due to negative slice values
- proper ruler uninitialize cleanup