### PR TITLE
fix(layouts): Make layouts more generic

### DIFF
--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -66,9 +66,12 @@
                       class="mt-0"
                       hide-details
                     >
-                      <v-radio label="Axial Primary" value="AxialPrimary" />
-                      <v-radio label="Quad View" value="QuadView" />
-                      <v-radio label="3D Only" value="ThreeOnly" />
+                      <v-radio
+                        v-for="(value, key) in Layouts"
+                        :key="key"
+                        :label="value.name"
+                        :value="key"
+                      />
                     </v-radio-group>
                   </v-card-text>
                 </v-card>
@@ -303,20 +306,12 @@ export default defineComponent({
 
     // --- layout --- //
 
-    const layoutName: Ref<'QuadView' | 'AxialPrimary'> = ref('QuadView');
+    const layoutName: Ref<keyof typeof Layouts> = ref('QuadView');
 
     const layoutGrid: ComputedRef<any> = computed(() => {
       const { layout } = viewStore;
       return toLayoutGridArray(layout);
     });
-
-    function relayoutAxial() {
-      layoutName.value = 'AxialPrimary';
-    }
-
-    function relayoutQuad() {
-      layoutName.value = 'QuadView';
-    }
 
     watch(
       layoutName,
@@ -431,8 +426,7 @@ export default defineComponent({
       messageCount,
       layout: layoutGrid,
       layoutName,
-      relayoutAxial,
-      relayoutQuad,
+      Layouts,
       userPromptFiles,
       openFiles,
       hasData,

--- a/src/config.ts
+++ b/src/config.ts
@@ -42,6 +42,7 @@ export const Layouts: Record<string, Layout> = {
         items: [Views.Coronal, Views.Sagittal, Views.Three],
       },
     ],
+    name: 'Axial Primary',
   },
   QuadView: {
     objType: 'Layout',
@@ -58,11 +59,13 @@ export const Layouts: Record<string, Layout> = {
         items: [Views.Sagittal, Views.Axial],
       },
     ],
+    name: 'Quad View',
   },
   ThreeOnly: {
     objType: 'Layout',
     direction: LayoutDirection.H,
     items: [Views.Three],
+    name: '3D Only',
   },
 };
 

--- a/src/store/views.ts
+++ b/src/store/views.ts
@@ -22,6 +22,7 @@ export interface View2DConfig {
   key: ViewKey;
   viewDirection: LPSAxisDir;
   viewUp: LPSAxisDir;
+  name?: string;
 }
 
 export interface View3DConfig {
@@ -29,6 +30,7 @@ export interface View3DConfig {
   key: ViewKey;
   viewDirection: LPSAxisDir;
   viewUp: LPSAxisDir;
+  name?: string;
 }
 
 export type ViewConfig = View2DConfig | View3DConfig;
@@ -38,6 +40,7 @@ export type Layout =
       objType: 'Layout';
       direction: LayoutDirection;
       items: Array<Layout | ViewConfig>;
+      name?: string;
     }
   | ViewConfig;
 


### PR DESCRIPTION
This fix allows to configure layouts only in the `config.ts` file, without having to modify the `App.vue` template.