### PR TITLE
feat(TwoView): sync windowing parameters

### DIFF
--- a/src/composables/sync/__tests__/createPrimitiveSyncContext.spec.ts
+++ b/src/composables/sync/__tests__/createPrimitiveSyncContext.spec.ts
@@ -1,0 +1,41 @@
+import Vue from 'vue';
+import VueCompositionApi, { ref } from '@vue/composition-api';
+import { expect } from 'chai';
+import { createPrimitiveSyncContext } from '../createPrimitiveSyncContext';
+
+describe('createPrimitiveSyncContext', () => {
+  before(() => {
+    Vue.use(VueCompositionApi);
+  });
+
+  it('should work', () => {
+    const useSync = createPrimitiveSyncContext(0);
+
+    const var1 = ref(0);
+    const var2 = ref(0);
+    const key1 = ref('key1');
+    const key2 = ref('key1');
+
+    useSync(key1, var1);
+    useSync(key2, var2);
+
+    expect(var1.value).to.equal(0);
+    expect(var2.value).to.equal(0);
+
+    var1.value = 2;
+
+    expect(var1.value).to.equal(2);
+    expect(var2.value).to.equal(2);
+
+    var2.value = 4;
+
+    expect(var1.value).to.equal(4);
+    expect(var2.value).to.equal(4);
+
+    key2.value = 'key2';
+    var2.value = 6;
+
+    expect(var1.value).to.equal(4);
+    expect(var2.value).to.equal(6);
+  });
+});

--- a/src/composables/sync/__tests__/useWindowingSync.spec.ts
+++ b/src/composables/sync/__tests__/useWindowingSync.spec.ts
@@ -1,0 +1,51 @@
+import Vue from 'vue';
+import VueCompositionApi, { computed, ref } from '@vue/composition-api';
+import { WindowLevelConfig } from '@/src/store/view-configs/windowing';
+import Sinon from 'sinon';
+import chai, { expect } from 'chai';
+import SinonChai from 'sinon-chai';
+import { useWindowingSync } from '../useWindowingSync';
+
+chai.use(SinonChai);
+
+function makeContext(k: string) {
+  const setSpy = Sinon.spy();
+  const windowing = ref<WindowLevelConfig>({
+    width: 1,
+    level: 0,
+    min: 0,
+    max: 10,
+  });
+  const key = ref(k);
+  const source = computed({
+    get: () => windowing.value,
+    set: (newValue) => {
+      setSpy(newValue);
+      windowing.value = newValue;
+    },
+  });
+
+  return { windowing, key, source, setSpy };
+}
+
+describe('useWindowingSync', () => {
+  before(() => {
+    Vue.use(VueCompositionApi);
+  });
+  it('should work', () => {
+    const ctxt1 = makeContext('abc');
+    const ctxt2 = makeContext('abc');
+
+    useWindowingSync(ctxt1.key, ctxt1.source);
+    useWindowingSync(ctxt2.key, ctxt2.source);
+
+    const newValue = {
+      ...ctxt1.windowing.value,
+      level: 4,
+    };
+    ctxt1.windowing.value = newValue;
+
+    expect(ctxt2.setSpy).to.have.been.calledWith(newValue);
+    expect(ctxt2.windowing.value.level).to.equal(newValue.level);
+  });
+});

--- a/src/composables/sync/createPrimitiveSyncContext.ts
+++ b/src/composables/sync/createPrimitiveSyncContext.ts
@@ -1,0 +1,83 @@
+import { ref, Ref, UnwrapRef, watch } from '@vue/composition-api';
+import { WatchOptions } from 'vue';
+
+/**
+ * immediate: sync from sync state to valueRef immediately.
+ */
+type SyncOptions = {
+  immediate: boolean;
+  watchOptions?: WatchOptions;
+};
+
+/**
+ * Only tested on primitive values.
+ */
+export function createPrimitiveSyncContext<T, K>(initialState: T) {
+  const states = new Map<K, Ref<UnwrapRef<T>>>();
+  const usage = new Map<K, number>();
+
+  const register = (key: K, valueRef: Ref<T>, options?: SyncOptions) => {
+    if (!states.has(key)) {
+      states.set(key, ref(initialState));
+    }
+    const state = states.get(key)!;
+    usage.set(key, 1 + (usage.get(key) ?? 0));
+
+    const stopTo = watch(
+      valueRef,
+      (newValue) => {
+        if (newValue !== state.value) {
+          state.value = newValue as UnwrapRef<T>;
+        }
+      },
+      {
+        flush: 'sync',
+        immediate: true,
+        ...options?.watchOptions,
+      }
+    );
+
+    const stopFrom = watch(
+      state,
+      (newState) => {
+        if (newState !== valueRef.value) {
+          /* eslint-disable-next-line no-param-reassign */
+          valueRef.value = newState as T;
+        }
+      },
+      {
+        flush: 'sync',
+        immediate: true,
+        ...options?.watchOptions,
+      }
+    );
+
+    return () => {
+      stopTo();
+      stopFrom();
+
+      usage.set(key, usage.get(key)! - 1);
+      if (usage.get(key) === 0) {
+        usage.delete(key);
+        states.delete(key);
+      }
+    };
+  };
+
+  const useSync = (key: Ref<K>, valueRef: Ref<T>, options?: SyncOptions) => {
+    let cleanup: (() => void) | null = null;
+    watch(
+      key,
+      (newKey) => {
+        if (cleanup) cleanup();
+        cleanup = register(newKey, valueRef, options);
+      },
+      {
+        flush: 'sync',
+        immediate: true,
+      }
+    );
+  };
+
+  return useSync;
+}

--- a/src/composables/sync/useWindowingSync.ts
+++ b/src/composables/sync/useWindowingSync.ts
@@ -1,0 +1,48 @@
+import { WindowLevelConfig } from '@/src/store/view-configs/windowing';
+import {
+  computed,
+  Ref,
+  triggerRef,
+  WritableComputedRef,
+} from '@vue/composition-api';
+import { createPrimitiveSyncContext } from './createPrimitiveSyncContext';
+
+function generateComputed(
+  source: WritableComputedRef<WindowLevelConfig | null>,
+  prop: keyof WindowLevelConfig
+) {
+  return computed({
+    get: () => source.value?.[prop] || null,
+    set: (newValue) => {
+      if (source.value && newValue != null) {
+        /* eslint-disable no-param-reassign */
+        source.value = {
+          ...source.value,
+          [prop]: newValue,
+        };
+      }
+    },
+  });
+}
+
+const useLevelSync = createPrimitiveSyncContext<number | null, string | null>(
+  0
+);
+const useWidthSync = createPrimitiveSyncContext<number | null, string | null>(
+  0
+);
+
+export function useWindowingSync(
+  dataID: Ref<string | null>,
+  source: WritableComputedRef<WindowLevelConfig | null>
+) {
+  const level = generateComputed(source, 'level');
+  const width = generateComputed(source, 'width');
+
+  // not 100% sure why, but this triggers tracking.
+  triggerRef(level);
+  triggerRef(width);
+
+  useLevelSync(dataID, level);
+  useWidthSync(dataID, width);
+}


### PR DESCRIPTION
Adds window & level syncing back in at the app level, and not the proxy level (which made it more difficult to track the current window/level properties).