### PR TITLE
Adds ruler jump-to

### DIFF
--- a/src/components/AnnotationsModule.vue
+++ b/src/components/AnnotationsModule.vue
@@ -13,14 +13,14 @@ export default defineComponent({
 </script>
 
 <template>
-  <v-container>
+  <div class="overflow-y-auto mx-2 fill-height">
     <v-list dense>
       <v-subheader class="annot-subheader">Measurements</v-subheader>
       <measurements-list />
       <v-subheader class="annot-subheader">Labelmaps</v-subheader>
       <labelmap-list />
     </v-list>
-  </v-container>
+  </div>
 </template>
 
 <style scoped>

--- a/src/components/ImageListCard.vue
+++ b/src/components/ImageListCard.vue
@@ -11,7 +11,7 @@
       v-on="$listeners"
     >
       <v-container>
-        <v-row no-gutters>
+        <v-row no-gutters class="flex-nowrap">
           <v-col v-if="selectable" cols="1" class="d-flex align-center">
             <v-checkbox
               @click.stop


### PR DESCRIPTION
- Ruler annotations now have a jump-to button.
- The ruler list is now filtered by the active image, instead of showing every available ruler.
- Measurements list was not correctly overflowing with a scroll bar.
- The image list card should not flex-wrap when the container width shrinks

Closes #138 

FYI @PaulHax @cjh1 @aylward 