### PR TITLE
ENH: Improve render quality by descreasing sample distance

### DIFF
--- a/src/components/VtkThreeView.vue
+++ b/src/components/VtkThreeView.vue
@@ -347,7 +347,7 @@ export default defineComponent({
               .reduce((sum, v) => sum + v, 0)
           );
 
-        mapper.setSampleDistance(sampleDistance / 2);
+        mapper.setSampleDistance(sampleDistance / 10);
 
         mapper.setGlobalIlluminationReach(params.enabled ? 0.5 : 0);
         property.setShade(true);


### PR DESCRIPTION
The heuristic for sample distance computation is too conservative
and produced significant speckle noise in the renderings.   This
commit decreases sample distance and image quality become quite good.