### PR TITLE
BUG: Remove slider appearing next to transfer func graph

### DIFF
--- a/src/components/VolumeRendering.vue
+++ b/src/components/VolumeRendering.vue
@@ -294,7 +294,7 @@ export default defineComponent({
 </script>
 
 <template>
-  <div class="overflow-x-hidden mx-2">
+  <div class="overflow-hidden">
     <div class="mt-4" ref="editorContainerRef">
       <div ref="pwfEditorRef" />
     </div>


### PR DESCRIPTION
Graph's frame now fits in x and y.  Also removed extra (redundant) padding in x.