### PR TITLE
ENH: Add option for light to follow camera and otherwise remain fixed

### DIFF
--- a/src/components/VolumeProperties.vue
+++ b/src/components/VolumeProperties.vue
@@ -104,18 +104,11 @@ export default defineComponent({
         @input="setCVRParam('diffuse', $event)"
       />
       <v-switch
-        label="Fixed/Camera Light"
+        label="Light follows camera"
         dense
         hide-details
-        :value="cvrParams.fixedLightPosition"
-        @change="setCVRParam('fixedLightPosition', $event)"
-      />
-      <v-switch
-        label="Anterior/Posterior Light"
-        dense
-        hide-details
-        :value="cvrParams.flipLightPosition"
-        @change="setCVRParam('flipLightPosition', $event)"
+        :value="cvrParams.lightFollowsCamera"
+        @change="setCVRParam('lightFollowsCamera', $event)"
       />
       <v-switch
         label="Enable Volumetric Scattering"

--- a/src/io/state-file/schema.ts
+++ b/src/io/state-file/schema.ts
@@ -158,8 +158,7 @@ const ColoringConfig: z.ZodType<ColoringConfig> = z.object({
 
 const CVRConfig: z.ZodType<CVRConfig> = z.object({
   enabled: z.boolean(),
-  flipLightPosition: z.boolean(),
-  fixedLightPosition: z.boolean(),
+  lightFollowsCamera: z.boolean(),
   useVolumetricScatteringBlending: z.boolean(),
   volumetricScatteringBlending: z.number(),
   useLocalAmbientOcclusion: z.boolean(),

--- a/src/store/view-configs/volume-coloring.ts
+++ b/src/store/view-configs/volume-coloring.ts
@@ -52,7 +52,7 @@ export const defaultVolumeColorConfig = (): VolumeColorConfig => ({
   },
   cvr: {
     enabled: false,
-    lightFollowsCamera: false,
+    lightFollowsCamera: true,
     useVolumetricScatteringBlending: false,
     volumetricScatteringBlending: 0,
     useLocalAmbientOcclusion: false,

--- a/src/store/view-configs/volume-coloring.ts
+++ b/src/store/view-configs/volume-coloring.ts
@@ -52,8 +52,7 @@ export const defaultVolumeColorConfig = (): VolumeColorConfig => ({
   },
   cvr: {
     enabled: false,
-    flipLightPosition: false,
-    fixedLightPosition: false,
+    lightFollowsCamera: false,
     useVolumetricScatteringBlending: false,
     volumetricScatteringBlending: 0,
     useLocalAmbientOcclusion: false,

--- a/src/types/views.ts
+++ b/src/types/views.ts
@@ -51,9 +51,7 @@ export interface ColoringConfig {
 export interface CVRConfig {
   enabled: boolean;
 
-  flipLightPosition: boolean;
-
-  fixedLightPosition: boolean;
+  lightFollowsCamera: boolean;
 
   useVolumetricScatteringBlending: boolean;
   volumetricScatteringBlending: number;


### PR DESCRIPTION
When option is enabled, light is a headlight and moves as camera moves.

When disabled, position of light is fixed if the camera is moved.

Allows the user to specify how shadows should be cast.