### PR TITLE
fix(ToolStrip): add separator under mouse tools

### DIFF
--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -75,7 +75,6 @@
                   </v-card-text>
                 </v-card>
               </v-menu>
-              <div class="mt-2 mb-1 tool-separator" />
               <template v-if="hasData">
                 <tool-strip />
               </template>
@@ -417,13 +416,6 @@ export default defineComponent({
 #tools-strip {
   border-left: 1px solid #212121;
   flex: 0 0 40px;
-}
-
-.tool-separator {
-  width: 75%;
-  height: 1px;
-  border: none;
-  border-top: 1px solid rgb(112, 112, 112);
 }
 
 .toolbar-button {

--- a/src/components/ItemGroup.vue
+++ b/src/components/ItemGroup.vue
@@ -47,7 +47,11 @@ export default {
     this.internalValue = this.value;
   },
   render(h) {
-    return h('div', null, this.$slots.default);
+    return h(
+      'div',
+      { props: this.$attrs, on: this.$listeners },
+      this.$slots.default
+    );
   },
   methods: {
     selectItem(itemValue) {

--- a/src/components/ToolStrip.vue
+++ b/src/components/ToolStrip.vue
@@ -1,5 +1,11 @@
 <template>
-  <item-group mandatory :value="currentTool" @change="setCurrentTool($event)">
+  <item-group
+    mandatory
+    class="d-flex flex-column align-center"
+    :value="currentTool"
+    @change="setCurrentTool($event)"
+  >
+    <div class="my-1 tool-separator" />
     <groupable-item
       v-slot:default="{ active, toggle }"
       :value="Tools.WindowLevel"
@@ -33,6 +39,7 @@
         @click="toggle"
       />
     </groupable-item>
+    <div class="my-1 tool-separator" />
     <groupable-item v-slot:default="{ active, toggle }" :value="Tools.Paint">
       <v-menu
         v-model="paintMenu"
@@ -167,5 +174,12 @@ export default defineComponent({
 .menu-more {
   position: absolute;
   right: -50%;
+}
+
+.tool-separator {
+  width: 75%;
+  height: 1px;
+  border: none;
+  border-top: 1px solid rgb(112, 112, 112);
 }
 </style>


### PR DESCRIPTION
Adds a separator under the mouse tools for delineation with the annotation tools.