### PR TITLE
fix(OpacityWidget): guard against unknown preset

### DIFF
--- a/src/utils/vtk-helpers.ts
+++ b/src/utils/vtk-helpers.ts
@@ -183,6 +183,8 @@ export function getColorFunctionRangeFromPreset(
   presetName: string
 ): [number, number] | null {
   const preset = vtkColorMaps.getPresetByName(presetName);
+  if (!preset) return null;
+
   const { AbsoluteRange, RGBPoints } = preset;
   if (AbsoluteRange && RGBPoints) {
     let min = Infinity;


### PR DESCRIPTION
This adds an extra guard against potentially unknown presets. (Not sure how it happens.)

Closes #206.