### PR TITLE
fix(ManipulatorTool): retain default mouse action across tools

### DIFF
--- a/src/components/styles/utils.css
+++ b/src/components/styles/utils.css
@@ -1,10 +1,10 @@
 .flex-equal {
-    flex: 1;
-    min-width: 0;
+  flex: 1;
+  min-width: 0;
 }
 
 .pointer-events-all {
-    pointer-events: all;
+  pointer-events: all;
 }
 
 .view-box {

--- a/src/components/tools/MouseManipulatorTool.vue
+++ b/src/components/tools/MouseManipulatorTool.vue
@@ -10,7 +10,7 @@ import {
 import { useViewStore } from '@/src/store/views';
 
 export default defineComponent({
-  name: 'ManipulatorTool',
+  name: 'MouseManipulatorTool',
   props: {
     // only useful for determining the kind of manipulator
     name: String,

--- a/src/components/tools/PanTool.vue
+++ b/src/components/tools/PanTool.vue
@@ -4,7 +4,7 @@ import vtkViewProxy from '@kitware/vtk.js/Proxy/Core/ViewProxy';
 import vtkMouseCameraTrackballPanManipulator from '@kitware/vtk.js/Interaction/Manipulators/MouseCameraTrackballPanManipulator';
 import { useToolStore } from '@/src/store/tools';
 import { Tools } from '@/src/store/tools/types';
-import ManipulatorTool from './ManipulatorTool.vue';
+import MouseManipulatorTool from './MouseManipulatorTool.vue';
 
 interface Props {
   viewProxy: vtkViewProxy;
@@ -21,7 +21,7 @@ export default {
       toolOptions.push({ button: 1 });
     }
 
-    return h(ManipulatorTool, {
+    return h(MouseManipulatorTool, {
       props: {
         ...ctx.props,
         name: 'PanTool',

--- a/src/components/tools/PanTool.vue
+++ b/src/components/tools/PanTool.vue
@@ -14,18 +14,19 @@ export default {
   functional: true,
   render(h: CreateElement, ctx: RenderContext<Props>) {
     const toolStore = useToolStore();
-    // only enable shift if Pan tool is not active
-    const shift = toolStore.currentTool !== Tools.Pan;
+    const toolOptions = [];
+    toolOptions.push({ button: 1, shift: true });
+    if (toolStore.currentTool === Tools.Pan) {
+      // Additionally enable left-button-only action if Pan tool is active
+      toolOptions.push({ button: 1 });
+    }
 
     return h(ManipulatorTool, {
       props: {
         ...ctx.props,
         name: 'PanTool',
         manipulatorClass: vtkMouseCameraTrackballPanManipulator,
-        options: {
-          button: 1,
-          shift,
-        },
+        options: toolOptions,
       },
     });
   },

--- a/src/components/tools/ZoomTool.vue
+++ b/src/components/tools/ZoomTool.vue
@@ -4,7 +4,7 @@ import vtkViewProxy from '@kitware/vtk.js/Proxy/Core/ViewProxy';
 import vtkMouseCameraTrackballZoomToMouseManipulator from '@kitware/vtk.js/Interaction/Manipulators/MouseCameraTrackballZoomToMouseManipulator';
 import { useToolStore } from '@/src/store/tools';
 import { Tools } from '@/src/store/tools/types';
-import ManipulatorTool from './ManipulatorTool.vue';
+import MouseManipulatorTool from './MouseManipulatorTool.vue';
 
 interface Props {
   viewProxy: vtkViewProxy;
@@ -21,7 +21,7 @@ export default {
       toolOptions.push({ button: 1 });
     }
 
-    return h(ManipulatorTool, {
+    return h(MouseManipulatorTool, {
       props: {
         ...ctx.props,
         name: 'ZoomTool',

--- a/src/components/tools/ZoomTool.vue
+++ b/src/components/tools/ZoomTool.vue
@@ -14,18 +14,19 @@ export default {
   functional: true,
   render(h: CreateElement, ctx: RenderContext<Props>) {
     const toolStore = useToolStore();
-    // only enable control button if Zoom tool is not active
-    const control = toolStore.currentTool !== Tools.Zoom;
+    const toolOptions = [];
+    toolOptions.push({ button: 1, control: true });
+    if (toolStore.currentTool === Tools.Zoom) {
+      // Additionally enable left-button-only action if Zoom tool is active
+      toolOptions.push({ button: 1 });
+    }
 
     return h(ManipulatorTool, {
       props: {
         ...ctx.props,
         name: 'ZoomTool',
         manipulatorClass: vtkMouseCameraTrackballZoomToMouseManipulator,
-        options: {
-          button: 1,
-          control,
-        },
+        options: toolOptions,
       },
     });
   },


### PR DESCRIPTION
Allow the default mouse actions (panning, zooming) to continue working with modifier keys even when the primary interaction tool (bound to left-mouse click-drag) is changed through the toolbar.

Addresses Issue: https://github.com/KitwareMedical/VolView/issues/172