### PR TITLE
Consistent 2D/3D mouse interaction

### DIFF
--- a/src/components/VtkThreeView.vue
+++ b/src/components/VtkThreeView.vue
@@ -6,6 +6,7 @@
       </div>
       <div class="overlay-no-events tool-layer">
         <crop-tool :view-id="viewID" />
+        <pan-tool :view-id="viewID" />
       </div>
       <view-overlay-grid class="overlay-no-events view-annotations">
         <template v-slot:top-left>
@@ -85,6 +86,7 @@ import {
 } from '../store/view-configs/volume-coloring';
 import { getShiftedOpacityFromPreset } from '../utils/vtk-helpers';
 import CropTool from './tools/CropTool.vue';
+import PanTool from './tools/PanTool.vue';
 import { useWidgetManager } from '../composables/useWidgetManager';
 import { VTKThreeViewWidgetManager } from '../constants';
 import { useCropStore } from '../store/tools/crop';
@@ -108,6 +110,7 @@ export default defineComponent({
   components: {
     ViewOverlayGrid,
     CropTool,
+    PanTool,
   },
   setup(props) {
     const modelStore = useModelStore();

--- a/src/components/tools/PanTool.vue
+++ b/src/components/tools/PanTool.vue
@@ -15,6 +15,7 @@ export default {
   render(h: CreateElement, ctx: RenderContext<Props>) {
     const toolStore = useToolStore();
     const toolOptions = [];
+    toolOptions.push({ button: 2 });
     toolOptions.push({ button: 1, shift: true });
     if (toolStore.currentTool === Tools.Pan) {
       // Additionally enable left-button-only action if Pan tool is active

--- a/src/components/tools/ZoomTool.vue
+++ b/src/components/tools/ZoomTool.vue
@@ -15,10 +15,11 @@ export default {
   render(h: CreateElement, ctx: RenderContext<Props>) {
     const toolStore = useToolStore();
     const toolOptions = [];
-    toolOptions.push({ button: 1, control: true });
+    toolOptions.push({ button: 3, flipDirection: true });
+    toolOptions.push({ button: 1, control: true, flipDirection: true });
     if (toolStore.currentTool === Tools.Zoom) {
       // Additionally enable left-button-only action if Zoom tool is active
-      toolOptions.push({ button: 1 });
+      toolOptions.push({ button: 1, flipDirection: true });
     }
 
     return h(MouseManipulatorTool, {


### PR DESCRIPTION
Addresses issue #193

Make mouse interaction consitent across 2D and 3D views.

Fix direction of 2D zooming (to be consistent with 3D zooming).

Add middle click for panning and right click for zooming in 2D.

Add middle click for panning in 3D.

Resulting state of interaction:
<html>
<body>
<!--StartFragment--><b style="font-weight:normal;" id="docs-internal-guid-8687c641-7fff-728c-8696-271cc8fd7575"><div dir="ltr" style="margin-left:0pt;" align="left">

Action | 2D | 3D
-- | -- | --
Left | grayscale | rotate
Mid | (proposed: pan) | (proposed: pan)
Right | (proposed: zoom) | zoom
Ctrl + Left | zoom | zoom
Shift + Left | pan | pan
Wheel | navigate slices | zoom

</div></b><!--EndFragment-->
</body>
</html>