### PR TITLE
ENH: Add additional space between data-loading options and secure note

### DIFF
--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -125,11 +125,11 @@
                         <v-icon size="64">mdi-arrow-down-bold</v-icon>
                       </div>
                       <div>Drag &amp; drop your DICOM files.</div>
+                      <br /> <br /> <br />
                       <div class="mt-16">
                         <v-icon size="64">mdi-cloud-off-outline</v-icon>
                       </div>
-                      <div>Local mode.</div>
-                      <div>Data stays on your machine.</div>
+                      <div>Secure: Your data never leaves your machine.</div>
                     </v-card>
                   </v-row>
                 </v-col>

--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -125,7 +125,9 @@
                         <v-icon size="64">mdi-arrow-down-bold</v-icon>
                       </div>
                       <div>Drag &amp; drop your DICOM files.</div>
-                      <br /> <br /> <br />
+                      <br />
+                      <br />
+                      <br />
                       <div class="mt-16">
                         <v-icon size="64">mdi-cloud-off-outline</v-icon>
                       </div>

--- a/src/components/App.vue
+++ b/src/components/App.vue
@@ -125,10 +125,7 @@
                         <v-icon size="64">mdi-arrow-down-bold</v-icon>
                       </div>
                       <div>Drag &amp; drop your DICOM files.</div>
-                      <br />
-                      <br />
-                      <br />
-                      <div class="mt-16">
+                      <div class="vertical-offset-margin">
                         <v-icon size="64">mdi-cloud-off-outline</v-icon>
                       </div>
                       <div>Secure: Your data never leaves your machine.</div>
@@ -427,5 +424,9 @@ export default defineComponent({
 
 .toolbar-button {
   min-height: 100%; /* fill toolbar height */
+}
+
+.vertical-offset-margin {
+  margin-top: 128px;
 }
 </style>


### PR DESCRIPTION
Added space so that loading options are confused with note about app being secure.

Also clarified the message about the app being secure.